### PR TITLE
Add Drupal Search API Elasticsearch module to list of projects

### DIFF
--- a/source/projects/index.markdown
+++ b/source/projects/index.markdown
@@ -19,3 +19,4 @@ Elastica is used in quite a few projects and libraries. In case you are using El
 * [useKit - teamwork across companies](http://useKit.com/)
 * [Wikimedia CirrusSearch](http://www.mediawiki.org/wiki/Extension:CirrusSearch)
 * [Zend Framework Boilerplate](http://zf-boilerplate.com)
+* [Search API Elasticsearch](https://www.drupal.org/project/search_api_elasticsearch) for [Drupal](https://www.drupal.org)


### PR DESCRIPTION
The Search API Elasticsearch module in Drupal uses Elastica to provide an Elasticsearch backend for Drupal's Search API.
