### PR TITLE
Removed PHP error in API landing page

### DIFF
--- a/source/api/index.html
+++ b/source/api/index.html
@@ -825,9 +825,7 @@
                 <section class="span10 offset1">
                     <hr />
                     Documentation is powered by <a href="http://www.phpdoc.org/">phpDocumentor </a> and authored
-                    on 
-Warning: date_default_timezone_get(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in phar:///usr/local/Cellar/phpdocumentor/2.7.0/libexec/phpDocumentor.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 89
-January 25th, 2015 at 13:17.
+                    on January 25th, 2015 at 13:17.
                 </section>
             </section>
         </section>


### PR DESCRIPTION
A PHP error is visible on http://elastica.io/api/

```
Documentation is powered by phpDocumentor and authored on

**Warning: date_default_timezone_get():
It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function.
In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier.
We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone.
in phar:///usr/local/Cellar/phpdocumentor/2.7.0/libexec/phpDocumentor.phar/vendor/twig/twig/lib/Twig/Extension/Core.php on line 89**

January 25th, 2015 at 13:17.
```