### PR TITLE
Fix the info about the HTTP client used by elasticsearch-php

### DIFF
--- a/source/elastica-vs-elasticsearch-php/index.md
+++ b/source/elastica-vs-elasticsearch-php/index.md
@@ -22,7 +22,7 @@ The following table should give a brief overview how Elastica and elasticsearch-
 | **Performance**			| good 				| good 					|
 | **Code size**				| medium 			| low 					|
 | **Paid Developers**		| no	 			| yes 					|
-| **Http Client**			| Selectable		| guzzle3 				|
+| **Http Client**			| Selectable		| guzzle 5				|
 
 
 # Code Snippets
@@ -54,7 +54,7 @@ $respone = $client->index($params);
 # History
 Elastica was in 2010 one of the first PHP clients for elasticsearch and was initially built for elasticsearch v0.16.0 and before. Since then a lot of things have changed in the elasticsearch API. Filter, facets, aggregations and more were added which also added complexity on the client side.
 
-In 2013 elasticsearch decided to unify all its elasticsearch client to have a common base and started to build elasticsearch-php. Since then, both clients are developen in parallel.
+In 2013 elasticsearch decided to unify all its elasticsearch client to have a common base and started to build elasticsearch-php. Since then, both clients are developed in parallel.
 
 
 # Elastica


### PR DESCRIPTION
elasticsearch-php is using guzzlehttp/ringphp, which is the low-level API of Guzzle 5, not of Guzzle 3.