### PR TITLE
Fix example for very basic searches

### DIFF
--- a/source/getting-started/search-documents.markdown
+++ b/source/getting-started/search-documents.markdown
@@ -71,6 +71,7 @@ $search->setQuery($query);
 
 Also it's possible to provide an array to create a new search. This array
 follows Elasticsearch request structure, e.g.:
+
 ```php
 $query = new \Elastica\Query([
     'query' => [
@@ -80,11 +81,15 @@ $query = new \Elastica\Query([
 
 $search->setQuery($query);
 ```
+
 For further information check out the [official documentation](https://www.elastic.co/guide/en/elasticsearch/reference/5.0/search-request-body.html).
 
 And for very basic searches it's also possible to just search for a term:
+
 ```php
-$query = new \Elastica\Query('search term');
+$term = new \Elastica\Query\Term(['_all' => 'search term']);
+
+$query = new \Elastica\Query($term);
 
 $search->setQuery($query);
 ```


### PR DESCRIPTION
Just passing a string does not work.

To proof my point, here is the [constructor of \Elastica\Query](https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Query.php#L37-L46):

```php
public function __construct($query = null)
{
    if (\is_array($query)) {
        $this->setRawQuery($query);
    } elseif ($query instanceof AbstractQuery) {
        $this->setQuery($query);
    } elseif ($query instanceof Suggest) {
        $this->setSuggest($query);
    }
}
```
